### PR TITLE
fix(seed): validate url as http(s) before crawling

### DIFF
--- a/pages/api/seed.ts
+++ b/pages/api/seed.ts
@@ -1,5 +1,6 @@
 import seed from "../../seed/seed"
 import { NextRequest, NextResponse } from 'next/server';
+import { parseHttpUrl } from "../../utils/validateUrl";
 
 
 export const config = {
@@ -7,7 +8,24 @@ export const config = {
 }
 
 const handler = async (req: NextRequest, res: NextResponse) => {
-  const { url } = await new Response(req.body).json();
+  let body: unknown;
+  try {
+    body = await new Response(req.body).json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  // Validate/sanitize the user-supplied URL before it reaches the crawler.
+  // parseHttpUrl rejects non-string, malformed, and non-http(s) input, so only
+  // a normalized http(s) href is ever passed downstream.
+  const url = parseHttpUrl((body as { url?: unknown } | null)?.url);
+  if (!url) {
+    return NextResponse.json(
+      { error: "`url` must be a valid http(s) URL" },
+      { status: 400 }
+    );
+  }
+
   await seed(url, 1, process.env.PINECONE_INDEX!, false)
   return NextResponse.json({ message: "done" })
 }

--- a/tests/mocked/seedHandler.test.ts
+++ b/tests/mocked/seedHandler.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub the seed module so the handler can be exercised without a crawler,
+// OpenAI, or a live Pinecone index. The point of these tests is the request
+// validation, not the downstream ingestion.
+// vi.mock is hoisted above module scope, so the mock fn must be created via
+// vi.hoisted to be available inside the factory.
+const seedMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+vi.mock("../../seed/seed", () => ({ default: seedMock }));
+
+import handler from "../../pages/api/seed";
+import { NextRequest } from "next/server";
+
+const post = (body: string) =>
+  handler(
+    new NextRequest("http://localhost/api/seed", { method: "POST", body }),
+    // The handler ignores its second arg; the edge signature just requires one.
+    undefined as never
+  );
+
+describe("seed API handler", () => {
+  beforeEach(() => {
+    seedMock.mockClear();
+  });
+
+  it("rejects a non-http(s) url with 400 and never calls seed", async () => {
+    const res = await post(JSON.stringify({ url: "javascript:alert(1)" }));
+    expect(res.status).toBe(400);
+    expect(seedMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed body with 400 and never calls seed", async () => {
+    const res = await post("not json");
+    expect(res.status).toBe(400);
+    expect(seedMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing url with 400 and never calls seed", async () => {
+    const res = await post(JSON.stringify({ notUrl: "x" }));
+    expect(res.status).toBe(400);
+    expect(seedMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a valid http(s) url and forwards the normalized href to seed", async () => {
+    const res = await post(JSON.stringify({ url: "https://example.com/docs" }));
+    expect(res.status).toBe(200);
+    expect(seedMock).toHaveBeenCalledTimes(1);
+    expect(seedMock.mock.calls[0][0]).toBe("https://example.com/docs");
+  });
+});

--- a/tests/unit/validateUrl.test.ts
+++ b/tests/unit/validateUrl.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseHttpUrl } from "../../utils/validateUrl";
+
+describe("parseHttpUrl", () => {
+  it("accepts http and https URLs and returns the normalized href", () => {
+    expect(parseHttpUrl("http://example.com")).toBe("http://example.com/");
+    expect(parseHttpUrl("https://example.com/docs")).toBe(
+      "https://example.com/docs"
+    );
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(parseHttpUrl("javascript:alert(1)")).toBeNull();
+    expect(parseHttpUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+    expect(parseHttpUrl("file:///etc/passwd")).toBeNull();
+    expect(parseHttpUrl("ftp://example.com")).toBeNull();
+  });
+
+  it("rejects malformed input", () => {
+    expect(parseHttpUrl("not a url")).toBeNull();
+    expect(parseHttpUrl("example.com")).toBeNull();
+    expect(parseHttpUrl("")).toBeNull();
+  });
+
+  it("rejects non-string values", () => {
+    expect(parseHttpUrl(undefined)).toBeNull();
+    expect(parseHttpUrl(null)).toBeNull();
+    expect(parseHttpUrl(42)).toBeNull();
+    expect(parseHttpUrl({})).toBeNull();
+  });
+});

--- a/utils/validateUrl.ts
+++ b/utils/validateUrl.ts
@@ -1,0 +1,24 @@
+// Validates that a user-supplied value is a well-formed http(s) URL.
+//
+// Parsing through the WHATWG `URL` constructor and only ever emitting the
+// normalized `href` sanitizes the value: anything that is not a string, not a
+// parseable URL, or carries a scheme other than http/https (e.g. `javascript:`,
+// `data:`, `file:`) is rejected before it can flow into a downstream sink. This
+// is the sanitizer that resolves the CodeQL `js/reflected-xss` finding on the
+// seed endpoint, where the request body's `url` was previously used unvalidated.
+export function parseHttpUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+
+  return parsed.href;
+}


### PR DESCRIPTION
## Problem

CodeQL reports an open **high-severity reflected cross-site scripting** alert (`js/reflected-xss`) at `pages/api/seed.ts:10`. The `/api/seed` edge handler read `url` straight from the request body and passed it into `seed()` (and the crawler) with no validation:

```ts
const { url } = await new Response(req.body).json();
await seed(url, 1, process.env.PINECONE_INDEX!, false)
```

Any caller could supply arbitrary input — including non-`http(s)` schemes (`javascript:`, `data:`, `file:`) or malformed values — which flowed unsanitized into a downstream sink. A malformed JSON body also threw an unhandled error rather than returning a clean response.

## Solution

Validate and sanitize the URL **at the handler, before it reaches `seed()`**, so the fix sits at the sink CodeQL flagged:

- New pure helper `utils/parseHttpUrl` parses the value through the WHATWG `URL` constructor, enforces the `http:`/`https:` protocol, and returns the **normalized `href`** (or `null`). Emitting only the parsed href is the sanitizer CodeQL recognizes — a `javascript:`/`data:` scheme or non-URL input can no longer pass through.
- `pages/api/seed.ts` now guards JSON parsing and rejects non-string / malformed / non-http(s) `url` with a `400` JSON response, forwarding only the validated href to `seed()`. Responses stay `application/json`.

Usage after the change:

```bash
# rejected with 400 — never reaches the crawler
curl -X POST /api/seed -d '{"url":"javascript:alert(1)"}'   # {"error":"`url` must be a valid http(s) URL"}
curl -X POST /api/seed -d 'not json'                         # {"error":"Invalid JSON body"}

# accepted — normalized href forwarded to seed()
curl -X POST /api/seed -d '{"url":"https://example.com/docs"}'  # {"message":"done"}
```

## Verification

All run locally against the test suite that landed in #1:

- `vitest run` — **17 passed, 1 e2e skipped** (added 4 sanitizer unit tests in `tests/unit/validateUrl.test.ts` and 4 handler tests in `tests/mocked/seedHandler.test.ts` that assert `seed()` is **never** called on rejected input and receives the normalized href on valid input).
- `tsc --noEmit` — clean.
- `next lint` — no warnings or errors.
- `next build` — production build succeeds; `/api/seed` compiles as an edge function.

The CodeQL alert should close on the next scan.

Closes #4
Refs #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)