### PR TITLE
test: cover the dependency-wrapping modules and fix a crawler bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "test:build": "next build"
   },
   "dependencies": {
@@ -37,6 +38,7 @@
     "@types/node": "^17.0.45",
     "@types/react": "18.2.6",
     "@types/url-parse": "^1.4.8",
+    "@vitest/coverage-v8": "3.2.7",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.36.0",
     "eslint-config-next": "^15.5.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@types/url-parse':
         specifier: ^1.4.8
         version: 1.4.11
+      '@vitest/coverage-v8':
+        specifier: 3.2.7
+        version: 3.2.7(supports-color@7.2.0)(vitest@3.2.7(@types/node@17.0.45)(jiti@1.21.7)(msw@2.15.0(@types/node@17.0.45)(typescript@4.9.5))(supports-color@7.2.0))
       autoprefixer:
         specifier: ^10.4.14
         version: 10.5.2(postcss@8.5.26)
@@ -124,6 +127,31 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -521,6 +549,14 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -633,6 +669,10 @@ packages:
   '@pinecone-database/pinecone@0.1.6':
     resolution: {integrity: sha512-tCnVc28udecthhgSBTdcMhYEW+xsR++AdZasp+ZE/AvUD1hOR2IR3edjk9m0sDxZyvXbno2KeqUbLIOZr7sCTw==}
     engines: {node: '>=14.0.0'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -1058,6 +1098,15 @@ packages:
       react: ^17.0.2 || ^18.0.0-0
       react-dom: ^17.0.2 || ^18.0.0-0
 
+  '@vitest/coverage-v8@3.2.7':
+    resolution: {integrity: sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==}
+    peerDependencies:
+      '@vitest/browser': 3.2.7
+      vitest: 3.2.7
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
@@ -1104,9 +1153,17 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1164,6 +1221,9 @@ packages:
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
@@ -1217,6 +1277,9 @@ packages:
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -1434,6 +1497,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   electron-to-chromium@1.5.389:
     resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
@@ -1710,6 +1776,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data@4.0.6:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
@@ -1765,6 +1835,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -1825,6 +1900,9 @@ packages:
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
@@ -1996,13 +2074,35 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2066,8 +2166,18 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2096,8 +2206,16 @@ packages:
   minimatch@3.1.4:
     resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
 
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2245,6 +2363,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2272,6 +2393,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -2564,6 +2689,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
     engines: {node: '>= 0.4'}
@@ -2590,6 +2719,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2639,6 +2772,10 @@ packages:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -2911,6 +3048,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2933,6 +3074,26 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -3202,6 +3363,17 @@ snapshots:
     optionalDependencies:
       '@types/node': 17.0.45
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3292,6 +3464,9 @@ snapshots:
       cross-fetch: 3.2.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -3624,6 +3799,25 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       sugar-high: 0.4.7
 
+  '@vitest/coverage-v8@3.2.7(supports-color@7.2.0)(vitest@3.2.7(@types/node@17.0.45)(jiti@1.21.7)(msw@2.15.0(@types/node@17.0.45)(typescript@4.9.5))(supports-color@7.2.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3(supports-color@7.2.0)
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6(supports-color@7.2.0)
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.7(@types/node@17.0.45)(jiti@1.21.7)(msw@2.15.0(@types/node@17.0.45)(typescript@4.9.5))(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -3682,9 +3876,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -3770,6 +3968,12 @@ snapshots:
 
   ast-types-flow@0.0.8: {}
 
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
   async-function@1.0.0: {}
 
   asynckit@0.4.0: {}
@@ -3815,6 +4019,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.1.4:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.9:
     dependencies:
@@ -4055,6 +4263,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.389: {}
 
@@ -4500,6 +4710,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
@@ -4571,6 +4786,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -4627,6 +4851,8 @@ snapshots:
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
+
+  html-escaper@2.0.2: {}
 
   htmlparser2@10.1.0:
     dependencies:
@@ -4797,6 +5023,27 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6(supports-color@7.2.0):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3(supports-color@7.2.0)
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   iterator.prototype@1.1.5:
     dependencies:
       define-data-property: 1.1.4
@@ -4806,7 +5053,15 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@1.21.7: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -4864,9 +5119,21 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   math-intrinsics@1.1.0: {}
 
@@ -4891,7 +5158,13 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.18
 
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.4
+
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -5068,6 +5341,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -5092,6 +5367,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
 
@@ -5432,6 +5712,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string.prototype.includes@2.0.1:
     dependencies:
       call-bind: 1.0.9
@@ -5486,6 +5772,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -5547,6 +5837,12 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   text-table@0.2.0: {}
 
@@ -5890,6 +6186,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/seed/crawler.ts
+++ b/seed/crawler.ts
@@ -1,4 +1,4 @@
-import cheerio from 'cheerio';
+import * as cheerio from 'cheerio';
 
 import { NodeHtmlMarkdown, NodeHtmlMarkdownOptions } from 'node-html-markdown'
 

--- a/tests/mocked/contextHandler.test.ts
+++ b/tests/mocked/contextHandler.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const embeddingMock = vi.hoisted(() => vi.fn());
+const matchesMock = vi.hoisted(() => vi.fn());
+vi.mock("../../utils/OpenAIEmbedding", () => ({ OpenAIEmbedding: embeddingMock }));
+vi.mock("../../pages/api/pinecone", () => ({ getMatchesFromEmbeddings: matchesMock }));
+
+import { getContext } from "../../pages/api/context";
+
+const match = (url: string, text: string) => ({ metadata: { url, text } });
+
+describe("getContext", () => {
+  beforeEach(() => {
+    embeddingMock.mockReset().mockResolvedValue([0.1, 0.2]);
+    matchesMock.mockReset();
+  });
+
+  it("embeds the message and joins the matched document texts", async () => {
+    matchesMock.mockResolvedValue([match("a", "alpha"), match("b", "beta")]);
+
+    const context = await getContext("question", {} as never, "documents");
+
+    expect(embeddingMock).toHaveBeenCalledWith("question");
+    expect(context).toBe("alpha\nbeta");
+  });
+
+  it("keeps only the first text per url", async () => {
+    matchesMock.mockResolvedValue([match("a", "first"), match("a", "second")]);
+
+    const context = await getContext("q", {} as never, "documents");
+
+    expect(context).toBe("first");
+  });
+
+  it("truncates the joined context to maxTokens characters", async () => {
+    matchesMock.mockResolvedValue([match("a", "x".repeat(50))]);
+
+    const context = await getContext("q", {} as never, "documents", 10);
+
+    expect(context).toHaveLength(10);
+  });
+});

--- a/tests/mocked/crawler.test.ts
+++ b/tests/mocked/crawler.test.ts
@@ -1,0 +1,69 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { Crawler } from "../../seed/crawler";
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const html = (body: string) =>
+  new HttpResponse(`<html><body>${body}</body></html>`, {
+    headers: { "Content-Type": "text/html" },
+  });
+
+describe("Crawler", () => {
+  it("fetches a page and converts its HTML to markdown", async () => {
+    server.use(
+      http.get("https://site.test/", () => html("<h1>Title</h1><p>Hello</p>"))
+    );
+
+    const pages = await new Crawler(2, 1).crawl("https://site.test/");
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].url).toBe("https://site.test/");
+    expect(pages[0].content).toContain("Title");
+    expect(pages[0].content).toContain("Hello");
+  });
+
+  it("follows links up to maxPages", async () => {
+    server.use(
+      http.get("https://site.test/", () =>
+        html('<a href="/next">next</a><p>first</p>')
+      ),
+      http.get("https://site.test/next", () => html("<p>second</p>"))
+    );
+
+    const pages = await new Crawler(2, 2).crawl("https://site.test/");
+
+    expect(pages.map((p) => p.url)).toEqual([
+      "https://site.test/",
+      "https://site.test/next",
+    ]);
+  });
+
+  it("does not descend past maxDepth", async () => {
+    server.use(
+      http.get("https://site.test/", () =>
+        html('<a href="/deep">deep</a><p>root</p>')
+      ),
+      http.get("https://site.test/deep", () => html("<p>should not fetch</p>"))
+    );
+
+    const pages = await new Crawler(0, 5).crawl("https://site.test/");
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].url).toBe("https://site.test/");
+  });
+
+  it("returns empty content when a fetch fails", async () => {
+    server.use(http.get("https://broken.test/", () => HttpResponse.error()));
+
+    const pages = await new Crawler(2, 1).crawl("https://broken.test/");
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].content).toBe("");
+  });
+});

--- a/tests/mocked/openaiCompletion.test.ts
+++ b/tests/mocked/openaiCompletion.test.ts
@@ -1,0 +1,91 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { OpenAICompletion } from "../../utils/OpenAICompletion";
+
+const server = setupServer();
+const ENDPOINT = "https://api.openai.com/v1/chat/completions";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+  server.resetHandlers();
+  delete process.env.AI_TEMP;
+  delete process.env.AI_MAX_TOKENS;
+  delete process.env.OPENAI_API_ORG;
+});
+afterAll(() => server.close());
+
+type Payload = {
+  model: string;
+  messages: { role: string; content: string }[];
+  temperature: number;
+  max_tokens: number;
+  stream: boolean;
+  n: number;
+};
+
+const capture = () => {
+  const seen: { body?: Payload; auth?: string | null; org?: string | null } = {};
+  server.use(
+    http.post(ENDPOINT, async ({ request }) => {
+      seen.body = (await request.json()) as Payload;
+      seen.auth = request.headers.get("authorization");
+      seen.org = request.headers.get("openai-organization");
+      return HttpResponse.json({ choices: [{ text: "ok" }] });
+    })
+  );
+  return seen;
+};
+
+describe("OpenAICompletion", () => {
+  it("returns the parsed JSON body from the API", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        HttpResponse.json({ choices: [{ text: "a summary" }] })
+      )
+    );
+
+    const result = await OpenAICompletion("summarize this");
+    expect(result).toEqual({ choices: [{ text: "a summary" }] });
+  });
+
+  it("wraps the prompt as a system message with model gpt-3.5-turbo", async () => {
+    const seen = capture();
+    await OpenAICompletion("my prompt");
+
+    expect(seen.body?.model).toBe("gpt-3.5-turbo");
+    expect(seen.body?.messages).toEqual([
+      { role: "system", content: "my prompt" },
+    ]);
+    expect(seen.body?.stream).toBe(true);
+    expect(seen.body?.n).toBe(1);
+  });
+
+  it("defaults temperature to 0.7 and max_tokens to 100", async () => {
+    const seen = capture();
+    await OpenAICompletion("x");
+
+    expect(seen.body?.temperature).toBe(0.7);
+    expect(seen.body?.max_tokens).toBe(100);
+  });
+
+  it("reads temperature and max_tokens from the environment", async () => {
+    process.env.AI_TEMP = "0.2";
+    process.env.AI_MAX_TOKENS = "512";
+    const seen = capture();
+    await OpenAICompletion("x");
+
+    expect(seen.body?.temperature).toBe(0.2);
+    expect(seen.body?.max_tokens).toBe(512);
+  });
+
+  it("sends the API key and organization headers", async () => {
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.OPENAI_API_ORG = "org-7";
+    const seen = capture();
+    await OpenAICompletion("x");
+
+    expect(seen.auth).toBe("Bearer test-key");
+    expect(seen.org).toBe("org-7");
+  });
+});

--- a/tests/mocked/openaiStream.test.ts
+++ b/tests/mocked/openaiStream.test.ts
@@ -1,0 +1,112 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { OpenAIStream, type OpenAIStreamPayload } from "../../utils/OpenAIStream";
+
+// Intercept at the network layer with a real SSE body so the eventsource-parser
+// + fetch streaming path stays covered across upgrades of either dependency.
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => {
+  server.resetHandlers();
+  delete process.env.OPENAI_API_ORG;
+});
+afterAll(() => server.close());
+
+const ENDPOINT = "https://api.openai.com/v1/chat/completions";
+
+const sse = (dataLines: string[]) => {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const line of dataLines) {
+        controller.enqueue(encoder.encode(`data: ${line}\n\n`));
+      }
+      controller.close();
+    },
+  });
+};
+
+const sseResponse = (dataLines: string[]) =>
+  new HttpResponse(sse(dataLines), {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+
+const drain = async (stream: ReadableStream<Uint8Array>) => {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value);
+  }
+  return out;
+};
+
+const delta = (content: string) =>
+  JSON.stringify({ choices: [{ delta: { content } }] });
+
+const payload: OpenAIStreamPayload = {
+  model: "gpt-3.5-turbo",
+  messages: [{ role: "user", content: "hi" }],
+  temperature: 0.7,
+  top_p: 1,
+  frequency_penalty: 0,
+  presence_penalty: 0,
+  max_tokens: 100,
+  stream: true,
+  n: 1,
+};
+
+describe("OpenAIStream", () => {
+  it("concatenates content deltas and closes on [DONE]", async () => {
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([delta("Hello"), delta(" world"), "[DONE]"])
+      )
+    );
+
+    const stream = await OpenAIStream(payload);
+    expect(await drain(stream)).toBe("Hello world");
+  });
+
+  it("drops a leading newline-only prefix delta", async () => {
+    // OpenAI's first deltas are often "\n\n"; the helper skips newline-bearing
+    // deltas while counter < 2, so the assembled text must omit them.
+    server.use(
+      http.post(ENDPOINT, () =>
+        sseResponse([delta("\n\n"), delta("Answer"), "[DONE]"])
+      )
+    );
+
+    const stream = await OpenAIStream(payload);
+    expect(await drain(stream)).toBe("Answer");
+  });
+
+  it("sends the API key and organization headers", async () => {
+    process.env.OPENAI_API_KEY = "test-key";
+    process.env.OPENAI_API_ORG = "org-42";
+    let auth: string | null = null;
+    let org: string | null = null;
+    server.use(
+      http.post(ENDPOINT, ({ request }) => {
+        auth = request.headers.get("authorization");
+        org = request.headers.get("openai-organization");
+        return sseResponse(["[DONE]"]);
+      })
+    );
+
+    await drain(await OpenAIStream(payload));
+    expect(auth).toBe("Bearer test-key");
+    expect(org).toBe("org-42");
+  });
+
+  it("errors the stream when a data frame is not valid JSON", async () => {
+    server.use(http.post(ENDPOINT, () => sseResponse(["not-json"])));
+
+    const stream = await OpenAIStream(payload);
+    await expect(drain(stream)).rejects.toBeInstanceOf(Error);
+  });
+});

--- a/tests/mocked/seedOrchestrator.test.ts
+++ b/tests/mocked/seedOrchestrator.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const crawl = vi.hoisted(() => vi.fn());
+const summarize = vi.hoisted(() => vi.fn());
+const embedding = vi.hoisted(() => vi.fn());
+const createIndexIfNotExists = vi.hoisted(() => vi.fn());
+const chunkedUpsert = vi.hoisted(() => vi.fn());
+const pineconeInit = vi.hoisted(() => vi.fn());
+const pineconeIndex = vi.hoisted(() => vi.fn());
+
+vi.mock("@pinecone-database/pinecone", () => ({
+  PineconeClient: class {
+    init = pineconeInit;
+    Index = pineconeIndex;
+  },
+}));
+vi.mock("../../seed/crawler", () => ({ Crawler: class { crawl = crawl; } }));
+vi.mock("../../seed/summarizer", () => ({ summarizeLongDocument: summarize }));
+vi.mock("../../utils/OpenAIEmbedding", () => ({ OpenAIEmbedding: embedding }));
+vi.mock("../../pages/api/pinecone", () => ({ createIndexIfNotExists, chunkedUpsert }));
+
+import seed from "../../seed/seed";
+
+describe("seed ingestion pipeline", () => {
+  beforeEach(() => {
+    crawl.mockReset().mockResolvedValue([
+      { url: "https://x.test/", content: "hello world" },
+    ]);
+    summarize.mockReset().mockResolvedValue("a summary");
+    embedding.mockReset().mockResolvedValue([0.1, 0.2, 0.3]);
+    createIndexIfNotExists.mockReset().mockResolvedValue(undefined);
+    chunkedUpsert.mockReset().mockResolvedValue(true);
+    pineconeInit.mockReset().mockResolvedValue(undefined);
+    pineconeIndex.mockReset().mockReturnValue({ id: "index" });
+  });
+
+  it("creates the index, crawls, embeds raw content, and upserts vectors", async () => {
+    await seed("https://x.test/", 10, "docs", false);
+
+    expect(createIndexIfNotExists).toHaveBeenCalledWith(expect.anything(), "docs", 1536);
+    expect(crawl).toHaveBeenCalledWith("https://x.test/");
+    expect(summarize).not.toHaveBeenCalled();
+    expect(embedding).toHaveBeenCalledWith("hello world");
+
+    expect(chunkedUpsert).toHaveBeenCalledTimes(1);
+    const [, vectors, namespace, chunkSize] = chunkedUpsert.mock.calls[0];
+    expect(namespace).toBe("documents");
+    expect(chunkSize).toBe(10);
+    expect(vectors[0].values).toEqual([0.1, 0.2, 0.3]);
+    expect(vectors[0].metadata.url).toBe("https://x.test/");
+    expect(vectors[0].metadata.chunk).toBe("hello world");
+  });
+
+  it("summarizes page content before embedding when summarize is true", async () => {
+    await seed("https://x.test/", 10, "docs", true);
+
+    expect(summarize).toHaveBeenCalledWith({ document: "hello world" });
+    expect(embedding).toHaveBeenCalledWith("a summary");
+  });
+});

--- a/tests/mocked/summarizer.test.ts
+++ b/tests/mocked/summarizer.test.ts
@@ -1,0 +1,46 @@
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { summarizeLongDocument } from "../../seed/summarizer";
+
+const server = setupServer();
+const ENDPOINT = "https://api.openai.com/v1/chat/completions";
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("summarizeLongDocument", () => {
+  it("returns a short document unchanged without calling the API", async () => {
+    const calls = vi.fn();
+    server.use(
+      http.post(ENDPOINT, () => {
+        calls();
+        return HttpResponse.json({ text: "unused" });
+      })
+    );
+
+    const doc = "a short document under the four-thousand character threshold";
+    const result = await summarizeLongDocument({ document: doc, inquiry: "q" });
+
+    expect(result).toBe(doc);
+    expect(calls).not.toHaveBeenCalled();
+  });
+
+  it("chunks and summarizes a document longer than 4000 characters", async () => {
+    const calls = vi.fn();
+    server.use(
+      http.post(ENDPOINT, () => {
+        calls();
+        return HttpResponse.json({ text: "s" });
+      })
+    );
+
+    const longDoc = "x".repeat(9000);
+    const result = await summarizeLongDocument({ document: longDoc, inquiry: "q" });
+
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeLessThan(longDoc.length);
+    expect(calls.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/tests/unit/pineconeClient.test.ts
+++ b/tests/unit/pineconeClient.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  chunkedUpsert,
+  createIndexIfNotExists,
+  getMatchesFromEmbeddings,
+  waitUntilIndexIsReady,
+} from "../../pages/api/pinecone";
+
+// These wrap the @pinecone-database/pinecone SDK but take the client as an
+// argument, so a hand-rolled fake exercises the wrapper logic without a live
+// index — the coverage that makes a Pinecone SDK upgrade safe to attempt.
+
+describe("chunkedUpsert", () => {
+  it("splits vectors into chunks and upserts each with the namespace", async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+    const index = { upsert } as never;
+    const vectors = Array.from({ length: 25 }, (_, i) => ({ id: `v${i}`, values: [i] }));
+
+    const ok = await chunkedUpsert(index, vectors as never, "ns", 10);
+
+    expect(ok).toBe(true);
+    expect(upsert).toHaveBeenCalledTimes(3);
+    const sizes = upsert.mock.calls.map((c) => c[0].upsertRequest.vectors.length);
+    expect(sizes).toEqual([10, 10, 5]);
+    for (const call of upsert.mock.calls) {
+      expect(call[0].upsertRequest.namespace).toBe("ns");
+    }
+  });
+
+  it("resolves true even when an individual chunk upsert rejects", async () => {
+    const upsert = vi.fn().mockRejectedValue(new Error("boom"));
+    const index = { upsert } as never;
+
+    await expect(
+      chunkedUpsert(index, [{ id: "a", values: [1] }] as never, "ns")
+    ).resolves.toBe(true);
+  });
+});
+
+describe("getMatchesFromEmbeddings", () => {
+  beforeEach(() => {
+    process.env.PINECONE_INDEX = "docs";
+  });
+  afterEach(() => {
+    delete process.env.PINECONE_INDEX;
+  });
+
+  it("returns [] when the configured index does not exist", async () => {
+    const pinecone = {
+      listIndexes: vi.fn().mockResolvedValue(["other"]),
+      Index: vi.fn(),
+    } as never;
+
+    const matches = await getMatchesFromEmbeddings([0.1], pinecone, 1, "ns");
+
+    expect(matches).toEqual([]);
+    expect((pinecone as { Index: unknown }).Index).not.toHaveBeenCalled();
+  });
+
+  it("queries the index and casts match metadata", async () => {
+    const query = vi.fn().mockResolvedValue({
+      matches: [{ id: "d1", score: 0.9, metadata: { url: "u", text: "t" } }],
+    });
+    const pinecone = {
+      listIndexes: vi.fn().mockResolvedValue(["docs"]),
+      Index: vi.fn().mockReturnValue({ query }),
+    } as never;
+
+    const matches = await getMatchesFromEmbeddings([0.1, 0.2], pinecone, 3, "ns");
+
+    expect(query).toHaveBeenCalledWith({
+      queryRequest: { vector: [0.1, 0.2], topK: 3, includeMetadata: true, namespace: "ns" },
+    });
+    expect(matches).toHaveLength(1);
+    expect(matches[0].metadata).toEqual({ url: "u", text: "t" });
+  });
+
+  it("throws a descriptive error when the query fails", async () => {
+    const pinecone = {
+      listIndexes: vi.fn().mockResolvedValue(["docs"]),
+      Index: vi.fn().mockReturnValue({
+        query: vi.fn().mockRejectedValue(new Error("upstream")),
+      }),
+    } as never;
+
+    await expect(
+      getMatchesFromEmbeddings([0.1], pinecone, 1, "ns")
+    ).rejects.toThrow(/Error querying embeddings/);
+  });
+});
+
+describe("createIndexIfNotExists", () => {
+  it("creates the index and waits for readiness when it is missing", async () => {
+    const client = {
+      listIndexes: vi.fn().mockResolvedValue([]),
+      createIndex: vi.fn().mockResolvedValue({}),
+      describeIndex: vi.fn().mockResolvedValue({ status: { ready: true } }),
+    } as never;
+
+    await createIndexIfNotExists(client, "docs", 1536);
+
+    const c = client as unknown as {
+      createIndex: ReturnType<typeof vi.fn>;
+      describeIndex: ReturnType<typeof vi.fn>;
+    };
+    expect(c.createIndex).toHaveBeenCalledWith({
+      createRequest: { name: "docs", dimension: 1536 },
+    });
+    expect(c.describeIndex).toHaveBeenCalled();
+  });
+
+  it("does not create the index when it already exists", async () => {
+    const createIndex = vi.fn();
+    const client = {
+      listIndexes: vi.fn().mockResolvedValue(["docs"]),
+      createIndex,
+    } as never;
+
+    await createIndexIfNotExists(client, "docs", 1536);
+
+    expect(createIndex).not.toHaveBeenCalled();
+  });
+});
+
+describe("waitUntilIndexIsReady", () => {
+  it("polls describeIndex until the index reports ready", async () => {
+    const describeIndex = vi
+      .fn()
+      .mockResolvedValueOnce({ status: { ready: false } })
+      .mockResolvedValueOnce({ status: { ready: true } });
+    const client = { describeIndex } as never;
+
+    await waitUntilIndexIsReady(client, "docs");
+
+    expect(describeIndex).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/textSplitter.test.ts
+++ b/tests/unit/textSplitter.test.ts
@@ -57,4 +57,42 @@ describe("RecursiveCharacterTextSplitter", () => {
     // Original metadata is preserved alongside the injected loc.
     expect(docs[0].metadata.url).toBe("src");
   });
+
+  it("recurses into a character split when a single token exceeds chunkSize", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 10, chunkOverlap: 0 });
+    const text = `hi ${"x".repeat(24)} bye`;
+
+    const chunks = await splitter.splitText(text);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.length).toBeLessThanOrEqual(splitter.chunkSize);
+    }
+    expect(chunks.join("")).toContain("x".repeat(24));
+  });
+
+  it("honors a custom separators list", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({
+      chunkSize: 12,
+      chunkOverlap: 0,
+      separators: ["|", ""],
+    });
+
+    const chunks = await splitter.splitText("alpha|beta|gamma");
+
+    expect(chunks.some((c) => c.includes("alpha"))).toBe(true);
+    expect(chunks.some((c) => c.includes("gamma"))).toBe(true);
+  });
+
+  it("splitDocuments skips documents with undefined pageContent", async () => {
+    const splitter = new RecursiveCharacterTextSplitter({ chunkSize: 100, chunkOverlap: 0 });
+    const docs = await splitter.splitDocuments([
+      new Document({ pageContent: "keep me", metadata: { url: "a" } }),
+      { pageContent: undefined as unknown as string, metadata: { url: "b" } } as Document,
+    ]);
+
+    expect(docs.length).toBe(1);
+    expect(docs[0].pageContent).toBe("keep me");
+    expect(docs[0].metadata.url).toBe("a");
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,18 @@ export default defineConfig({
     environment: "node",
     globals: true,
     include: ["tests/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      // Scope coverage to the backend/dependency-wrapping code these tests
+      // target; the React components need a DOM harness and are out of scope.
+      include: ["utils/**", "seed/**", "pages/api/**"],
+      thresholds: {
+        statements: 75,
+        branches: 80,
+        functions: 80,
+        lines: 75,
+      },
+    },
   },
 });


### PR DESCRIPTION
**PR 2 of 3** — base `claude/deps-security` (#23). Retargets to `main` automatically once #23 merges.

Adds test coverage focused on the code that wraps upgrade-prone dependencies, so a future SDK bump is caught by tests rather than in production.

## Changes
- New Vitest suites: `OpenAIStream` (eventsource-parser + fetch streaming), `OpenAICompletion`, `crawler` (cheerio + node-html-markdown), `summarizer`, the Pinecone client wrappers, the `seed` ingestion pipeline, and `getContext`.
- Extend `TextSplitter` tests: recursion into char-splits, custom separators, `splitDocuments`.
- Add `@vitest/coverage-v8` + a `test:coverage` script with **enforced thresholds** so coverage can't silently regress. Backend surface: **17 → 48 tests, ~81% lines**.

### Latent bug fixed
`seed/crawler.ts` imported the cheerio **default export**, but cheerio 1.x is ESM with named exports only — `cheerio.load` was `undefined` under a real ESM loader and only worked via webpack's CJS interop in the Next build. Switched to a namespace import that works under both. The new crawler tests reproduce and guard it.

## Verification
`pnpm test:coverage` (thresholds enforced) and `pnpm typecheck` pass.