### PR TITLE
ci: add GitHub Actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Lint, typecheck & test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage report
+        if: matrix.node-version == 24
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage
+          path: coverage/
+          if-no-files-found: ignore
+
+  build:
+    name: Production build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+  audit:
+    name: Dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Audit (fail on high or critical)
+        run: pnpm audit --audit-level=high


### PR DESCRIPTION
**PR 3 of 3** — base `claude/test-coverage` (#24). Retargets down the stack automatically as the earlier PRs merge; merge this **last**.

Depends on the earlier PRs: the `test:coverage` step needs #24, and the `audit --audit-level=high` gate only passes with #23.

## Changes
- **`.github/workflows/ci.yml`** — on push/PR to `main`, a Node **22 + 24** matrix with pnpm caching runs `lint` → `typecheck` → `test:coverage` (uploads the coverage artifact); a separate **build** job; and an **audit** job (`pnpm audit`) that fails on high/critical advisories — an active per-PR vulnerability scan.
- Actions pinned to current majors: `actions/checkout@v7`, `actions/setup-node@v7`, `actions/upload-artifact@v7`, `pnpm/action-setup@v6`.

## Not included
No `.github/dependabot.yml` — routine Dependabot version-update PRs are intentionally omitted. Vulnerability **scanning/alerts** (Dependabot alerts) are a repo setting under Settings → Code security and continue independently; the CI `audit` job above adds a per-PR scan gate.

## Verification
Every CI command was run locally on Node 24.18: `lint`, `typecheck`, `test:coverage`, `audit --audit-level=high`, and `build` all pass. YAML parses.