### PR TITLE
ci: add least-privilege permissions + Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   quality:
     name: Lint, typecheck & test


### PR DESCRIPTION
## What

Fills the two remaining gaps that kept `vercel-chatbot-template` off the top CI tier. The workflow is already strong — Node 22+24 matrix, lint, typecheck, `test:coverage`, production build, and a `pnpm audit --audit-level=high` gate. This adds:

1. **Least-privilege permissions** — a top-level `permissions: contents: read` block. All three jobs only read the repo (the coverage upload needs no extra scope), so this is safe.
2. **`.github/dependabot.yml`** — weekly npm + github-actions updates (grouped).

## Verification

- `pnpm audit` → **0 known vulnerabilities**, so the existing audit gate stays green.
- Both YAML files validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)