### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+# Auto-requests review from the owners below on every pull request.
+# Docs: https://docs.github.com/articles/about-code-owners
+
+* @pinecone-io/dev-advocates


### PR DESCRIPTION
Adds `.github/CODEOWNERS` so pull requests automatically request review from the appropriate owners.

Owners: `@pinecone-io/dev-advocates`

Part of an org-wide rollout to ensure every public repo has code owners configured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub metadata only; no application code, runtime behavior, or security-sensitive logic changes.
> 
> **Overview**
> Introduces **`.github/CODEOWNERS`** with a default `*` rule so **every pull request** automatically requests review from **`@pinecone-io/dev-advocates`**, aligning this repo with the org-wide code owners rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcf04f5e5a5a1d6da8abdda891c81a180aee1d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->